### PR TITLE
Handler.repeat and Handler.cancelAll extension functions

### DIFF
--- a/core/src/main/kotlin/com/mcxiaoke/koi/ext/Handler.kt
+++ b/core/src/main/kotlin/com/mcxiaoke/koi/ext/Handler.kt
@@ -20,6 +20,18 @@ inline fun <T : Any> Handler.atTime(uptimeMillis: Long, crossinline action: () -
 inline fun <T : Any> Handler.delayed(delayMillis: Long, crossinline action: () -> T): Boolean
         = postDelayed({ action() }, delayMillis)
 
+inline fun <T : Any> Handler.repeat(delayMillis: Long, startDelayMillis: Long = 0, repeatCount: Int = 0, crossinline action: (Int) -> T) {
+    val startDelay = if (startDelayMillis < 0) 0 else startDelayMillis
+    val repeats = if (repeatCount < 0) 0 else repeatCount
+    var counter = 0
+    postDelayed(object : Runnable {
+        override fun run() {
+            action(counter ++)
+            if (repeats == 0 || counter < repeats) postDelayed(this, delayMillis)
+        }
+    }, startDelay)
+}
+
 fun handler(handleMessage: (Message) -> Boolean): Handler {
     return Handler { p -> if (p == null) false else handleMessage(p) }
 }

--- a/core/src/main/kotlin/com/mcxiaoke/koi/ext/Handler.kt
+++ b/core/src/main/kotlin/com/mcxiaoke/koi/ext/Handler.kt
@@ -32,6 +32,8 @@ inline fun <T : Any> Handler.repeat(delayMillis: Long, startDelayMillis: Long = 
     }, startDelay)
 }
 
+fun Handler.cancelAll() = removeCallbacksAndMessages(null)
+
 fun handler(handleMessage: (Message) -> Boolean): Handler {
     return Handler { p -> if (p == null) false else handleMessage(p) }
 }

--- a/core/src/main/kotlin/com/mcxiaoke/koi/ext/Handler.kt
+++ b/core/src/main/kotlin/com/mcxiaoke/koi/ext/Handler.kt
@@ -21,15 +21,15 @@ inline fun <T : Any> Handler.delayed(delayMillis: Long, crossinline action: () -
         = postDelayed({ action() }, delayMillis)
 
 inline fun <T : Any> Handler.repeat(delayMillis: Long, startDelayMillis: Long = 0, repeatCount: Int = 0, crossinline action: (Int) -> T) {
-    val startDelay = if (startDelayMillis < 0) 0 else startDelayMillis
-    val repeats = if (repeatCount < 0) 0 else repeatCount
+    if (startDelayMillis < 0) throw IllegalArgumentException("Start delay must be a positive Int or 0")
+    if (repeatCount < 0) throw IllegalArgumentException("Repeat count must be a positive Int or 0")
     var counter = 0
     postDelayed(object : Runnable {
         override fun run() {
             action(counter ++)
-            if (repeats == 0 || counter < repeats) postDelayed(this, delayMillis)
+            if (repeatCount == 0 || counter < repeatCount) postDelayed(this, delayMillis)
         }
-    }, startDelay)
+    }, startDelayMillis)
 }
 
 fun Handler.cancelAll() = removeCallbacksAndMessages(null)

--- a/samples/src/main/kotlin/com/mcxiaoke/koi/samples/HandlerSample.kt
+++ b/samples/src/main/kotlin/com/mcxiaoke/koi/samples/HandlerSample.kt
@@ -28,9 +28,19 @@ class HandlerExtensionSample {
         // equal to
         handler.postAtTime({ print("perform action after 5s") }, 5000)
 
-        handler.delayed(3000, { print("perform action after 5s") })
+        handler.delayed(3000, { print("perform action after 3s") })
         // equal to
-        handler.postDelayed({ print("perform action after 5s") }, 3000)
+        handler.postDelayed({ print("perform action after 3s") }, 3000)
 
+        // repeating actions
+        handler.repeat(3000) { print("perform action indefinitely every 3s") }
+
+        handler.repeat(
+                delayMillis = 1000,
+                startDelayMillis = 3000,
+                repeatCount = 5
+        ) {
+            print("perform action 5 times every 3s starting 1s after initial call")
+        }
     }
 }

--- a/samples/src/main/kotlin/com/mcxiaoke/koi/samples/HandlerSample.kt
+++ b/samples/src/main/kotlin/com/mcxiaoke/koi/samples/HandlerSample.kt
@@ -42,5 +42,8 @@ class HandlerExtensionSample {
         ) {
             print("perform action 5 times every 3s starting 1s after initial call")
         }
+
+        // cancels all pending messages and callbacks
+        handler.cancelAll()
     }
 }


### PR DESCRIPTION
More often than not, I find myself creating a `Runnable` which posts itself to a `Handler` with a delay, thus creating a repeatable action.

In order to do this, `Handler.postDelayed` method has to be called with an `object` that implements the `Runnable` interface. This is done so that it can be referenced later.

Instead of assuming what would be the start delay and what would be the repeat count, this function offers these options as parameters with default values. By default, there is no start delay and the action repeats indefinitely.

In addition to that, I've added the `Handler.cancelAll` function which simply calls `Handler. removeCallbacksAndMessages` with a `null` parameter. The name `cancelAll` is more descriptive, shorter and easier to understand.

I did not commit a sample usage, nor did I update the _README.md_ file. However, I did test this on a few devices and it works as expected.
